### PR TITLE
added DATABASE_URL setting and conn setting to heroku settings

### DIFF
--- a/mysite/heroku.py
+++ b/mysite/heroku.py
@@ -8,6 +8,8 @@ from .settings import *
 
 DATABASES = {
     "default": dj_database_url.config(
+        conn_max_age=600,
+        ssl_require=True,
         default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
     )
 }

--- a/mysite/heroku.py
+++ b/mysite/heroku.py
@@ -10,7 +10,7 @@ DATABASES = {
     "default": dj_database_url.config(
         conn_max_age=600,
         ssl_require=True,
-        default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
+        default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3"),
     )
 }
 

--- a/mysite/heroku.py
+++ b/mysite/heroku.py
@@ -24,5 +24,5 @@ MIDDLEWARE = (
 )
 
 
-DATABASE_URL = os.environ['DATABASE_URL']
-conn = psycopg2.connect(DATABASE_URL, sslmode='require')
+DATABASE_URL = os.environ["DATABASE_URL"]
+conn = psycopg2.connect(DATABASE_URL, sslmode="require")

--- a/mysite/heroku.py
+++ b/mysite/heroku.py
@@ -2,6 +2,8 @@ import os
 
 import dj_database_url
 
+import psycopg2
+
 from .settings import *
 
 DATABASES = {
@@ -20,3 +22,7 @@ MIDDLEWARE = (
     "whitenoise.middleware.WhiteNoiseMiddleware",
     *MIDDLEWARE,
 )
+
+
+DATABASE_URL = os.environ['DATABASE_URL']
+conn = psycopg2.connect(DATABASE_URL, sslmode='require')


### PR DESCRIPTION
According to the heroku dev center, the following needs to be in the code to use a postgresql database:

    import os
    import psycopg2

    DATABASE_URL = os.environ['DATABASE_URL']

    conn = psycopg2.connect(DATABASE_URL, sslmode='require')

I am adding it to see if that fixes the problem with not being able to log on to the admin page.

