### PR TITLE
Change pp2b version

### DIFF
--- a/mysite/heroku.py
+++ b/mysite/heroku.py
@@ -10,7 +10,7 @@ DATABASES = {
     )
 }
 
-DEBUG = True
+DEBUG = False
 TEMPLATE_DEBUG = False
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 SECRET_KEY = os.environ.get("SECRET_KEY")

--- a/mysite/heroku.py
+++ b/mysite/heroku.py
@@ -10,7 +10,7 @@ DATABASES = {
     )
 }
 
-DEBUG = False
+DEBUG = True
 TEMPLATE_DEBUG = False
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 SECRET_KEY = os.environ.get("SECRET_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gunicorn==20.1.0
 mypy-extensions==0.4.3
 pathspec==0.9.0
 platformdirs==2.4.0
-psycopg2-binary==2.9.3
+psycopg2-binary==2.8.6
 pytz==2021.3
 tomli==1.2.3
 whitenoise==5.3.0


### PR DESCRIPTION
Based on the conversation on github referenced below, there is a compatiblilty problem with older versions of Django and psycopg 2.9.  One suggested solution was reverting to version 2.8.6.

(https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147)