### PR TITLE
trying version of Django that is supposed to work with version of psy…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ black==22.1.0
 click==8.0.4
 colorama==0.4.4
 dj-database-url==0.5.0
-Django==2.1.1
+Django==2.2.27
 gunicorn==20.1.0
 mypy-extensions==0.4.3
 pathspec==0.9.0
 platformdirs==2.4.0
-psycopg2-binary==2.9.3
+psycopg2-binary==2.8.6
 pytz==2021.3
 tomli==1.2.3
 whitenoise==5.3.0


### PR DESCRIPTION
Upgrading to a newer version of Django that is supposed to be compatible with psycopg2-binary 2.8.6 with regards to how the timezones are handled.